### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "java10"
+run = "print YEET"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 # Wurst-MC-1.12
 Wurst Client for Minecraft 1.12 - 1.12.2
+[![Run on Repl.it](https://repl.it/badge/github/coolpic783/Wurst-MC-1.12)](https://repl.it/github/coolpic783/Wurst-MC-1.12)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).